### PR TITLE
Add support for initial constructor arguments

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+Revision history for perl distribution MooseX-Test-Role
+
+    - Adds support for initial constructor arguments (MJGARDNER)
+
 0.04    2014-03-01
 
     - Adds support for Role::Tiny and Moo::Role (newer versions of Moo::Role

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,6 @@
 name = MooseX-Test-Role
 author = Paul Boyd <boyd.paul2@gmail.com>
+author = Mark Gardner <mjgardner@cpan.org>
 license = Perl_5
 copyright_holder = Paul Boyd
 copyright_year = 2014

--- a/t/04_consumer_of.t
+++ b/t/04_consumer_of.t
@@ -26,7 +26,8 @@ sub test_role_type {
         my $role = util::make_role(
             type             => $type,
             required_methods => ['c'],
-            methods          => [ 'sub a { "return a" }', ]
+            methods          => [ 'sub a { "return a" }' ],
+            attributes       => ['arg'],
         );
 
         my $consumer = consumer_of($role);
@@ -46,6 +47,16 @@ sub test_role_type {
 
         $consumer = consumer_of( $role, c => sub { 'custom c' } );
         is( $consumer->c, 'custom c', 'explicit methods override the default' );
+
+        if ($type eq 'Moose::Role' or $type eq 'Moo::Role') {
+            my @args = ($role, [arg => 1]);
+
+            $consumer = consumer_of(@args);
+            ok( $consumer->arg, 'constructor argument' );
+
+            $consumer = consumer_of(@args, c => sub {'custom c'});
+            ok( $consumer->arg, 'constructor argument and method' );
+        }
     }
 }
 

--- a/t/util.pm
+++ b/t/util.pm
@@ -10,6 +10,7 @@ sub make_role {
     my $type             = $args{type};
     my $required_methods = $args{required_methods};
     my $methods          = $args{methods} || [];
+    my $attributes_ref   = $args{attributes} || [];
 
     my $required_source = '';
 
@@ -17,6 +18,11 @@ sub make_role {
         $required_source = 'requires qw( ';
         $required_source .= join( ' ', @{$required_methods} );
         $required_source .= ' );';
+    }
+
+    if ($type eq 'Moose::Role' or $type eq 'Moo::Role') {
+        $required_source .= join "\n" =>
+            map {"has $_ => (is => 'ro');"} @{$attributes_ref};
     }
 
     my $package = 'TestRole' . $role_sequence++;


### PR DESCRIPTION
Roles with attributes or other arguments required at construction need a way to specify those arguments in consumer_of(). This patch adds support for that by checking if the second argument is an arrayref, and if so passing its contents to the instance's new() method if it exists.
