### PR TITLE
add scalars for methods as a shortcut

### DIFF
--- a/t/05_consuming_object.t
+++ b/t/05_consuming_object.t
@@ -73,6 +73,15 @@ sub test_role_type {
         $consumer = consuming_object(
             $role,
             methods => {
+                d => 'from d'
+            }
+        );
+        is( $consumer->d, 'from d',
+            'scalar values can be passed to consuming_object to create object methods' );
+
+        $consumer = consuming_object(
+            $role,
+            methods => {
                 appender => sub { 'x' }
             }
         );

--- a/t/06_consuming_class.t
+++ b/t/06_consuming_class.t
@@ -58,6 +58,15 @@ sub test_role_type {
             }
         );
         is( $consumer->c, 'custom c', 'explicit methods override the default' );
+
+        $consumer = consuming_object(
+            $role,
+            methods => {
+                d => 'from d'
+            }
+        );
+        is( $consumer->d, 'from d',
+            'scalar values can be passed to consuming_object to create object methods' );
     }
 }
 


### PR DESCRIPTION
If there are a lot of methods (e.g. accessors) in a class that are required in a role and those need to be set over and over when creating a test
role-object, one needs to repeat `foo => sub { "foo" }` a lot. To make that less tedious, it will now check if the thing assigned to a method name
 is a scalar (not a ref) and in that case wrap it in an anonymous sub. That makes it similar to what Moose does when declaring a scalar as a default value for an attribute.

It will still break when you assign something other than a coderef or a scalar, e.g. a hashref.